### PR TITLE
krb5-sync-backend: Add an ending newline to error messages

### DIFF
--- a/tools/krb5-sync-backend
+++ b/tools/krb5-sync-backend
@@ -318,7 +318,7 @@ sub process {
                 for my $ignore (@IGNORE) {
                     next STDERR if $line =~ m{ $ignore }xms;
                 }
-                print {*STDERR} $line
+                print {*STDERR} $line, "\n"
                   or warn "$0: cannot write to standard error: $!\n";
             }
         } else {


### PR DESCRIPTION
For --silent we're splitting up the errors by \n, which strips the
newlines from each line.  Print out with an explicit \n so that errors
don't all run together.
